### PR TITLE
Made threads continuous using detach() function. #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # VisionTracking
-Vision Tracking Sub-module Included into WML, To make vision tracking easier for other teams with pre-threaded processes and given known functions. Like X,Y center figures, distance detection, square and circle detection.
+Vision Tracking Sub-module library, To make vision tracking easier for other teams with pre-threaded processes and given known functions. Like X,Y center figures, distance detection, square and circle detection.
 
 You may be wondering why it's called CJ Vision... well it was either that or Potato Vision, and i prefer self promotion. hehehehe

--- a/src/cpp/VisTrack.cpp
+++ b/src/cpp/VisTrack.cpp
@@ -6,49 +6,43 @@ const int RETRO_HSV_MAX = 78;
 const int RETRO_VALUE_MIN = 100;
 const int RETRO_VALUE_MAX = 255;
 
-cv::Mat CJ::VisionTracking::SetupVision(int CamPort, int FPS, int ResHeight, int ResWidth, int Exposure, std::string Name, bool RetroTrack) {
+void CJ::VisionTracking::SetupVision(cv::Mat *ImageSrc, int CamPort, int FPS, int ResHeight, int ResWidth, int Exposure, std::string Name, bool RetroTrack) {
   if (RetroTrack == true){ Exposure = -100; }
   cam = Camera.cam.CamSetup(CamPort, FPS, ResHeight, ResWidth, Exposure, Name);
 
-  ImageSrc = Camera.cam.ImageReturn(cam, Name);
-
-  return ImageSrc;
+  *ImageSrc = Camera.cam.ImageReturn(cam, Name);
 }
 
-cv::Mat CJ::VisionTracking::RetroTrack(cv::Mat Img, int ErosionSize, int DialationSize) {
-  if (Camera.cam.sink.GrabFrame(Img) != 0) {
-    cv::cvtColor(Img, imgTracking, cv::COLOR_BGR2HSV); // Uses HSV Spectrum
+void CJ::VisionTracking::RetroTrack(cv::Mat *OutputImage, cv::Mat InputImage, int ErosionSize, int DialationSize) {
+  if (Camera.cam.sink.GrabFrame(InputImage) != 0) {
+    cv::cvtColor(InputImage, *OutputImage, cv::COLOR_BGR2HSV); // Uses HSV Spectrum
 
     // Keeps Only green pixles
-    cv::inRange(imgTracking, cv::Scalar(RETRO_HSV_MIN, RETRO_VALUE_MIN, RETRO_VALUE_MIN), cv::Scalar(RETRO_HSV_MAX, RETRO_VALUE_MAX, RETRO_VALUE_MAX), imgTracking);
+    cv::inRange(*OutputImage, cv::Scalar(RETRO_HSV_MIN, RETRO_VALUE_MIN, RETRO_VALUE_MIN), cv::Scalar(RETRO_HSV_MAX, RETRO_VALUE_MAX, RETRO_VALUE_MAX), *OutputImage);
 
     // Removes pixles at a certain size, And dilates the image to get rid of gaps
     if (ErosionSize > 0) {
-      cv::erode(imgTracking, imgTracking, cv::getStructuringElement(cv::MORPH_ELLIPSE, cv::Size(ErosionSize, ErosionSize)));
-      cv::dilate(imgTracking, imgTracking, cv::getStructuringElement(cv::MORPH_ELLIPSE, cv::Size(DialationSize, DialationSize)));
+      cv::erode(*OutputImage, *OutputImage, cv::getStructuringElement(cv::MORPH_ELLIPSE, cv::Size(ErosionSize, ErosionSize)));
+      cv::dilate(*OutputImage, *OutputImage, cv::getStructuringElement(cv::MORPH_ELLIPSE, cv::Size(DialationSize, DialationSize)));
     }
   } else {
-    std::cout << "Error Getting Image" << std::endl;
+    std::cout << "Error Getting Image (Function Retro Track)" << std::endl;
   }
-
-  return imgTracking;
 }
 
-cv::Mat CJ::VisionTracking::CustomTrack(cv::Mat Img, int HSVColourLowRange, int HSVColourHighRange, int ValueColourLowRange, int ValueColourHighRange, int CamExposure, int ErosionSize, int DialationSize, cs::UsbCamera cam) {
-  if (Camera.cam.sink.GrabFrame(Img) != 0) {
-    cv::cvtColor(Img, imgTracking, cv::COLOR_BGR2HSV); // Uses HSV Spectrum
+void CJ::VisionTracking::CustomTrack(cv::Mat *OutputImage, cv::Mat InputImage, int HSVColourLowRange, int HSVColourHighRange, int ValueColourLowRange, int ValueColourHighRange, int CamExposure, int ErosionSize, int DialationSize, cs::UsbCamera cam) {
+  if (Camera.cam.sink.GrabFrame(InputImage) != 0) {
+    cv::cvtColor(InputImage, *OutputImage, cv::COLOR_BGR2HSV); // Uses HSV Spectrum
 
     // Keeps Only green pixles
-    cv::inRange(imgTracking, cv::Scalar(HSVColourLowRange, ValueColourLowRange, ValueColourLowRange), cv::Scalar(HSVColourHighRange, ValueColourHighRange, ValueColourHighRange), imgTracking);
+    cv::inRange(*OutputImage, cv::Scalar(HSVColourLowRange, ValueColourLowRange, ValueColourLowRange), cv::Scalar(HSVColourHighRange, ValueColourHighRange, ValueColourHighRange), *OutputImage);
     
     // Removes pixles at a certain size, And dilates the image to get rid of gaps
     if (ErosionSize > 0) {
-      cv::erode(imgTracking, imgTracking, cv::getStructuringElement(cv::MORPH_ELLIPSE, cv::Size(ErosionSize, ErosionSize)));
-      cv::dilate(imgTracking, imgTracking, cv::getStructuringElement(cv::MORPH_ELLIPSE, cv::Size(DialationSize, DialationSize)));
+      cv::erode(*OutputImage, *OutputImage, cv::getStructuringElement(cv::MORPH_ELLIPSE, cv::Size(ErosionSize, ErosionSize)));
+      cv::dilate(*OutputImage, *OutputImage, cv::getStructuringElement(cv::MORPH_ELLIPSE, cv::Size(DialationSize, DialationSize)));
     }
   } else {
     std::cout << "Error Getting Image" << std::endl;
   }
-
-  return imgTracking;
 }

--- a/src/cpp/VisTrack.cpp
+++ b/src/cpp/VisTrack.cpp
@@ -6,6 +6,8 @@ const int RETRO_HSV_MAX = 78;
 const int RETRO_VALUE_MIN = 100;
 const int RETRO_VALUE_MAX = 255;
 
+CJ::VisionTracking vision;
+
 void CJ::VisionTracking::SetupVision(cv::Mat *ImageSrc, int CamPort, int FPS, int ResHeight, int ResWidth, int Exposure, std::string Name, bool RetroTrack) {
   if (RetroTrack == true){ Exposure = -100; }
   cam = Camera.cam.CamSetup(CamPort, FPS, ResHeight, ResWidth, Exposure, Name);
@@ -13,8 +15,8 @@ void CJ::VisionTracking::SetupVision(cv::Mat *ImageSrc, int CamPort, int FPS, in
   *ImageSrc = Camera.cam.ImageReturn(cam, Name);
 }
 
-void CJ::VisionTracking::RetroTrack(cv::Mat *OutputImage, cv::Mat InputImage, int ErosionSize, int DialationSize) {
-  if (Camera.cam.sink.GrabFrame(InputImage) != 0) {
+void RetroTrackThread(cv::Mat *OutputImage, cv::Mat InputImage, int ErosionSize, int DialationSize) {
+  do {
     cv::cvtColor(InputImage, *OutputImage, cv::COLOR_BGR2HSV); // Uses HSV Spectrum
 
     // Keeps Only green pixles
@@ -25,10 +27,17 @@ void CJ::VisionTracking::RetroTrack(cv::Mat *OutputImage, cv::Mat InputImage, in
       cv::erode(*OutputImage, *OutputImage, cv::getStructuringElement(cv::MORPH_ELLIPSE, cv::Size(ErosionSize, ErosionSize)));
       cv::dilate(*OutputImage, *OutputImage, cv::getStructuringElement(cv::MORPH_ELLIPSE, cv::Size(DialationSize, DialationSize)));
     }
+  } while (true);
+}
+
+void CJ::VisionTracking::RetroTrack(cv::Mat *OutputImage, cv::Mat InputImage, int ErosionSize, int DialationSize) {
+  if (Camera.cam.sink.GrabFrame(InputImage) != 0) {
+    std::thread RetroThread(RetroTrackThread, OutputImage, InputImage, ErosionSize, DialationSize);
   } else {
     std::cout << "Error Getting Image (Function Retro Track)" << std::endl;
   }
 }
+
 
 void CJ::VisionTracking::CustomTrack(cv::Mat *OutputImage, cv::Mat InputImage, int HSVColourLowRange, int HSVColourHighRange, int ValueColourLowRange, int ValueColourHighRange, int CamExposure, int ErosionSize, int DialationSize, cs::UsbCamera cam) {
   if (Camera.cam.sink.GrabFrame(InputImage) != 0) {

--- a/src/cpp/VisTrack.cpp
+++ b/src/cpp/VisTrack.cpp
@@ -16,23 +16,22 @@ void CJ::VisionTracking::SetupVision(cv::Mat *ImageSrc, int CamPort, int FPS, in
 }
 
 void RetroTrackThread(cv::Mat *OutputImage, cv::Mat InputImage, int ErosionSize, int DialationSize) {
-  do {
-    cv::cvtColor(InputImage, *OutputImage, cv::COLOR_BGR2HSV); // Uses HSV Spectrum
+  cv::cvtColor(InputImage, *OutputImage, cv::COLOR_BGR2HSV); // Uses HSV Spectrum
 
-    // Keeps Only green pixles
-    cv::inRange(*OutputImage, cv::Scalar(RETRO_HSV_MIN, RETRO_VALUE_MIN, RETRO_VALUE_MIN), cv::Scalar(RETRO_HSV_MAX, RETRO_VALUE_MAX, RETRO_VALUE_MAX), *OutputImage);
+  // Keeps Only green pixles
+  cv::inRange(*OutputImage, cv::Scalar(RETRO_HSV_MIN, RETRO_VALUE_MIN, RETRO_VALUE_MIN), cv::Scalar(RETRO_HSV_MAX, RETRO_VALUE_MAX, RETRO_VALUE_MAX), *OutputImage);
 
-    // Removes pixles at a certain size, And dilates the image to get rid of gaps
-    if (ErosionSize > 0) {
-      cv::erode(*OutputImage, *OutputImage, cv::getStructuringElement(cv::MORPH_ELLIPSE, cv::Size(ErosionSize, ErosionSize)));
-      cv::dilate(*OutputImage, *OutputImage, cv::getStructuringElement(cv::MORPH_ELLIPSE, cv::Size(DialationSize, DialationSize)));
-    }
-  } while (true);
+  // Removes pixles at a certain size, And dilates the image to get rid of gaps
+  if (ErosionSize > 0) {
+    cv::erode(*OutputImage, *OutputImage, cv::getStructuringElement(cv::MORPH_ELLIPSE, cv::Size(ErosionSize, ErosionSize)));
+    cv::dilate(*OutputImage, *OutputImage, cv::getStructuringElement(cv::MORPH_ELLIPSE, cv::Size(DialationSize, DialationSize)));
+  }
 }
 
 void CJ::VisionTracking::RetroTrack(cv::Mat *OutputImage, cv::Mat InputImage, int ErosionSize, int DialationSize) {
   if (Camera.cam.sink.GrabFrame(InputImage) != 0) {
     std::thread RetroThread(RetroTrackThread, OutputImage, InputImage, ErosionSize, DialationSize);
+    RetroThread.join();
   } else {
     std::cout << "Error Getting Image (Function Retro Track)" << std::endl;
   }

--- a/src/cpp/VisionProcessingType.cpp
+++ b/src/cpp/VisionProcessingType.cpp
@@ -1,7 +1,11 @@
 #include "VisionProcessingType.h"
 
-void CJ::VisionProcessing::VisionEdgeDetection::CannyTrack(cv::Mat img, int Threshold) {
+void CannyTrackThread(cv::Mat, int Threshold) {
 
+}
+void CJ::VisionProcessing::VisionEdgeDetection::CannyTrack(cv::Mat img, int Threshold) {
+  std::thread CannyThread(CannyTrackThread, img, Threshold);
+  if (CannyThread.joinable()) {CannyThread.join();}
 }
 
 void CJ::VisionProcessing::VisionEdgeDetection::ContourDetect(cv::Mat img) {

--- a/src/include/VisTrack.h
+++ b/src/include/VisTrack.h
@@ -7,8 +7,12 @@
 #include "opencv2/highgui/highgui.hpp"
 #include "opencv2/imgproc/imgproc.hpp"
 #include "opencv2/core/core.hpp"
+
+// Base Libraries
 #include <stdio.h>
 #include <iostream>
+#include <thread>
+#include <mutex>
 
 // Tracking Libraires
 #include "VisionCameras.h"
@@ -24,7 +28,8 @@ namespace CJ {
       //cv::Mat ImageSrc;
       //cv::Mat imgTracking;
       cs::UsbCamera cam;
-      
+
+
       /** 
        * Sets up vision using OpenCV & Camera Servers
        */
@@ -35,12 +40,14 @@ namespace CJ {
        * Track using retro reflective tape, Using low exposure and Green pixle filtering
        * Using the defaults for the colour spectrum and exposure settings.
        */
-      void RetroTrack(cv::Mat *OutputImage , cv::Mat InputImage, int ErosionSize, int DialationSize);
+      void RetroTrack(cv::Mat *OutputImage, cv::Mat InputImage, int ErosionSize, int DialationSize);
+
 
       /**
        * Track using your own adjusted settings for the colour spectrum and exposure
        */
       void CustomTrack(cv::Mat *OutputImage, cv::Mat InputImage, int HSVColourLowRange, int HSVColourHighRange, int ValueColourLowRange, int ValueColourHighRange, int CamExposure, int ErosionSize, int DialationSize, cs::UsbCamera cam);
+
 
       // Instances
       VisionCamera Camera;

--- a/src/include/VisTrack.h
+++ b/src/include/VisTrack.h
@@ -41,13 +41,13 @@ namespace CJ {
        * Track using retro reflective tape, Using low exposure and Green pixle filtering
        * Using the defaults for the colour spectrum and exposure settings.
        */
-      void RetroTrack(cv::Mat *OutputImage, cv::Mat InputImage, int ErosionSize, int DialationSize);
+      void RetroTrack(cv::Mat *OutputImage, cv::Mat *InputImage, int ErosionSize, int DialationSize);
 
 
       /**
        * Track using your own adjusted settings for the colour spectrum and exposure
        */
-      void CustomTrack(cv::Mat *OutputImage, cv::Mat InputImage, int HSVColourLowRange, int HSVColourHighRange, int ValueColourLowRange, int ValueColourHighRange, int CamExposure, int ErosionSize, int DialationSize, cs::UsbCamera cam);
+      void CustomTrack(cv::Mat *OutputImage, cv::Mat *InputImage, int HSVColourLowRange, int HSVColourHighRange, int ValueColourLowRange, int ValueColourHighRange, int CamExposure, int ErosionSize, int DialationSize, cs::UsbCamera cam);
 
 
       // Instances

--- a/src/include/VisTrack.h
+++ b/src/include/VisTrack.h
@@ -28,6 +28,7 @@ namespace CJ {
       //cv::Mat ImageSrc;
       //cv::Mat imgTracking;
       cs::UsbCamera cam;
+      cv::Mat *MatPtr;
 
 
       /** 

--- a/src/include/VisTrack.h
+++ b/src/include/VisTrack.h
@@ -21,26 +21,26 @@
 namespace CJ {
   class VisionTracking {
     public:
-      cv::Mat ImageSrc;
-      cv::Mat imgTracking;
+      //cv::Mat ImageSrc;
+      //cv::Mat imgTracking;
       cs::UsbCamera cam;
       
       /** 
        * Sets up vision using OpenCV & Camera Servers
        */
-      cv::Mat SetupVision(int CamPort, int FPS, int ResHeight, int ResWidth, int Exposure, std::string CamName, bool RetroTrack);
+      void SetupVision(cv::Mat *ImageImage , int CamPort, int FPS, int ResHeight, int ResWidth, int Exposure, std::string CamName, bool RetroTrack);
 
 
       /**
        * Track using retro reflective tape, Using low exposure and Green pixle filtering
        * Using the defaults for the colour spectrum and exposure settings.
        */
-      cv::Mat RetroTrack(cv::Mat Img, int ErosionSize, int DialationSize);
+      void RetroTrack(cv::Mat *OutputImage , cv::Mat InputImage, int ErosionSize, int DialationSize);
 
       /**
        * Track using your own adjusted settings for the colour spectrum and exposure
        */
-      cv::Mat CustomTrack(cv::Mat Img, int HSVColourLowRange, int HSVColourHighRange, int ValueColourLowRange, int ValueColourHighRange, int CamExposure, int ErosionSize, int DialationSize, cs::UsbCamera cam);
+      void CustomTrack(cv::Mat *OutputImage, cv::Mat InputImage, int HSVColourLowRange, int HSVColourHighRange, int ValueColourLowRange, int ValueColourHighRange, int CamExposure, int ErosionSize, int DialationSize, cs::UsbCamera cam);
 
       // Instances
       VisionCamera Camera;

--- a/src/include/VisionProcessingType.h
+++ b/src/include/VisionProcessingType.h
@@ -7,6 +7,8 @@
 #include "opencv2/highgui/highgui.hpp"
 #include "opencv2/imgproc/imgproc.hpp"
 #include "opencv2/core/core.hpp"
+#include <thread>
+#include <mutex>
 #include <stdio.h>
 #include <iostream>
 


### PR DESCRIPTION
This has also increased performance for the vision tracking. 
Because the tracking/processing images are separate to the original image. Even if the thread running the current process lags or freezes. The origin image would still be fine, giving the same FPS. Perfect for teams who want to feed their cameras through the coprocessor to network tables without lag from it's processing.

In other words. you can use the camera both as a tracking camera and a driver camera. Unless it's being used to track retro tape. In which case the you wouldn't be able to see the origin image anyway because the exposure is set to -100...
why did i do this again? what slim group of people are going to use the camera as a tracking camera and a driver camera. But NOT track retro tape??
Whatever you welcome